### PR TITLE
Small improvement to constants

### DIFF
--- a/R/constants.R
+++ b/R/constants.R
@@ -11,6 +11,4 @@ names(DEBUG) <- "DEBUG"
 TRACE <- 9L
 names(TRACE) <- "TRACE"
 
-.LOG_LEVEL <- c('FATAL','ERROR',NA,'WARN', NA,'INFO', NA,'DEBUG','TRACE')
-
 

--- a/R/layout.R
+++ b/R/layout.R
@@ -5,7 +5,7 @@ layout.simple <- function(level, msg, ...)
 {
   the.time <- format(Sys.time(), "%Y-%m-%d %H:%M:%S")
   if (! is.null(substitute(...))) msg <- sprintf(msg, ...)
-  sprintf("%s [%s] %s\n", .LOG_LEVEL[level],the.time, msg)
+  sprintf("%s [%s] %s\n", names(level),the.time, msg)
 }
 
 # This parses and prints a user-defined format string. Available tokens are


### PR DESCRIPTION
When I was writing a custom layout function, I read the code to layout.simple. I quickly realized and I had no access to .LOG_LEVEL and so would have to replicate the code to turn a numeric log level into a meaningful string.

I have written and tested this alternative - assigning the string version of the level as the name of the constants:

```
> str(DEBUG)
 Named int 8
 - attr(*, "names")= chr "DEBUG"
> names(DEBUG)
[1] "DEBUG"
```

This way, .LOG_LEVEL is no longer necessary and the same data is available to package users when they write their custom layout functions. Now we can do away with .LOG_LEVEL completely and rewrite layout.simple as follows:

```
layout.simple <- function(level, msg, ...)
{
  the.time <- format(Sys.time(), "%Y-%m-%d %H:%M:%S")
  if (! is.null(substitute(...))) msg <- sprintf(msg, ...)
  sprintf("%s [%s] %s\n", names(level),the.time, msg)
}
```

I have also set the constant values to be integer rather than numeric, just for efficiency purposes.
