### PR TITLE
Added new test for capture output

### DIFF
--- a/inst/tests/test_logger.R
+++ b/inst/tests/test_logger.R
@@ -6,6 +6,13 @@ test_that("Default settings", {
   expect_that(length(grep('log message', raw)) > 0, is_true())
 })
 
+test_that("Capture works as expected", {
+  raw <- capture.output(flog.info("log message", head(cars), capture = TRUE))
+  expect_that(length(raw) == 9, is_true())
+  expect_that(grepl('^INFO',raw[1]), is_true())
+  expect_that(grepl('dist$',raw[3]), is_true())
+  })
+
 test_that("Change root threshold", {
   flog.threshold(ERROR)
   raw <- capture.output(flog.info("log message"))


### PR DESCRIPTION
Uses "cars" as example data object to print.

This test fails on 1.3.5, bu passes on 1.3.1. Others untested. 
