### PR TITLE
FIX: Make sure that `utils` package is loaded.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,6 +8,7 @@ Maintainer: Brian Lee Yung Rowe <r@zatonovo.com>
 Depends:
     R (>= 3.0.0)
 Imports:
+    utils,
     lambda.r (>= 1.1.0),
     futile.options
 Suggests:


### PR DESCRIPTION
This fix is required to make futile.logger work under Rscript, which does not load e.g. 'utils' and 'methods' by default. Could you please prefix `capture.output` and other functions in such possibly unattached namespaces with, e.g. `utils::`? Then importing 'utils' completely is no longer needed.