### PR TITLE
Function name and namepsace detection

### DIFF
--- a/R/logger.R
+++ b/R/logger.R
@@ -124,7 +124,6 @@
 #' z <- getIndexComposition()
 #'
 #' }
-NULL
 
 .log_level <- function(msg, ..., level, name, capture)
 {
@@ -147,10 +146,18 @@ NULL
 
 # Get the namespace that a function resides in. If no namespace exists, then
 # return NULL.
+# @param .where: where in the call stack should be check. 
+#             0: current function (always
+#            -1: parents of this function.
+#            -3: when used within flog.*, 
+#                it refers to the original caller of flog.*
+#            -4: when used from flogger.name within a .log_level
+#
 # <environment: namespace:lambda.r>
-flog.namespace <- function(where=1)
+flog.namespace <- function(.where=-4)
 {
-  s <- capture.output(str(topenv(environment(sys.function(where))), give.attr=FALSE))
+  sf <- sys.function(.where - 1)
+  s <- capture.output(str(topenv(environment(sf)), give.attr=FALSE))
   if (length(grep('lambda.r',s)) > 0)
     s <- attr(sys.function(-5), 'topenv')
 
@@ -159,7 +166,6 @@ flog.namespace <- function(where=1)
   ns <- sub('.*namespace:([^>]+)>.*','\\1', s)
   ifelse(is.null(ns), 'ROOT', ns)
 }
-
 
 flog.trace <- function(msg, ..., name=flog.namespace(), capture=FALSE) {
   .log_level(msg, ..., level=TRACE,name=name, capture=capture)

--- a/R/logger.R
+++ b/R/logger.R
@@ -124,6 +124,7 @@
 #' z <- getIndexComposition()
 #'
 #' }
+NULL
 
 .log_level <- function(msg, ..., level, name, capture)
 {

--- a/tests/testthat/test_layout.R
+++ b/tests/testthat/test_layout.R
@@ -53,3 +53,15 @@ test_that("some extra arguments are passed", {
           capture.output(
             flog.info('%s and %s equals to %s', 'foo', 'bar', 'foobar'))))
 })
+
+context("Function name and namespace detection")
+test_that("Function name detection inside nested functions", {
+    flog.layout(layout.format("[~f] ~m"))
+    a <- function() { flog.info("inside A") }
+    b <- function() { a() }
+    d <- function() { b() }
+    e <- function() { d() }
+    expect_equal('[a] inside A', capture.output(e()))
+    flog.layout(layout.simple)
+})
+


### PR DESCRIPTION
Not sure if this is a bug or by design, but here is a solution (or alternative if this is by design).

When detecting namespace or function name, `flog.namespace` uses the first element on the call stack, which is usually irrelevant to the function calling the `flog.xxx` series.

For example,
```R
library(futile.logger)

flog.layout(layout.format("[~f] ~m"))
a_caller <- function() { flog.info("inside A") }
b <- function() { a_caller() }
d <- function() { b() }
e <- function() { d() }

e()
```
prints
```
R> [e] inside A
```
while one expects
```
R> [a_caller] inside A
```

A similar thing happens for the namespaces (the `[~n]`) specially inside packages.

In the pull request, flog.namespace was changed to find the correct function from the other side of the call stack.
