### PR TITLE
Dynamic log filename

### DIFF
--- a/R/appender.R
+++ b/R/appender.R
@@ -40,7 +40,7 @@
 #'
 #' \code{appender.file2} is similar, but the filename is dynamically
 #' determined at runtime. It may include most of the same tokens as
-#' \code{\link{layout.format}} (all except \code{"~m"}, the message
+#' \code{layout.format} (all except \code{"~m"}, the message
 #' itself). This allows, for instance, having separate logfiles for
 #' each log level.
 #' 

--- a/R/appender.R
+++ b/R/appender.R
@@ -126,10 +126,12 @@ appender.file2 <- function(format, console = FALSE,
     the.namespace <- ifelse(the.namespace == 'futile.logger', 'ROOT', the.namespace)
     the.function <- .get.parent.func.name(.funcwhere)
     the.function <- ifelse(the.function == '(shell)', default.func, the.function)
+    the.pid <- Sys.getpid()
     filename <- gsub('~l', the.level, format, fixed=TRUE)
     filename <- gsub('~t', the.time, filename, fixed=TRUE)
     filename <- gsub('~n', the.namespace, filename, fixed=TRUE)
     filename <- gsub('~f', the.function, filename, fixed=TRUE)
+    filename <- gsub('~p', the.pid, filename, fixed=TRUE)
     cat(line, file=filename, append=TRUE, sep='')
   }
 }

--- a/R/appender.R
+++ b/R/appender.R
@@ -111,12 +111,12 @@ appender.tee <- function(file){
 }
 
 # Write to a dynamically-named file (and optionally the console)
-appender.file2 <- function(format, console = FALSE,
-                           default.func = "shell", datetime.fmt = "%Y%m%dT%H%M%S"){
-  .nswhere = -3 # get name of the function 2 deep in the call stack
-                # that is, the function that has called flog.*
-  .funcwhere = -3 # ditto for the function name
-  .levelwhere = -1 # ditto for the current "level"
+appender.file2 <- function(format, console=FALSE,
+                           datetime.fmt="%Y%m%dT%H%M%S") {
+  .nswhere <- -3 # get name of the function 2 deep in the call stack
+                 # that is, the function that has called flog.*
+  .funcwhere <- -3 # ditto for the function name
+  .levelwhere <- -1 # ditto for the current "level"
   function(line) {
     if (console) cat(line, sep='')
     the.level <- tryCatch(names(get("level", envir=sys.frame(.levelwhere))),
@@ -125,7 +125,6 @@ appender.file2 <- function(format, console = FALSE,
     the.namespace <- flog.namespace(.nswhere)
     the.namespace <- ifelse(the.namespace == 'futile.logger', 'ROOT', the.namespace)
     the.function <- .get.parent.func.name(.funcwhere)
-    the.function <- ifelse(the.function == '(shell)', default.func, the.function)
     the.pid <- Sys.getpid()
     filename <- gsub('~l', the.level, format, fixed=TRUE)
     filename <- gsub('~t', the.time, filename, fixed=TRUE)

--- a/R/appender.R
+++ b/R/appender.R
@@ -119,7 +119,7 @@ appender.file2 <- function(format, console = FALSE,
   .levelwhere = -1 # ditto for the current "level"
   function(line) {
     if (console) cat(line, sep='')
-    the.level <- tryCatch(names(get("level", env=sys.frame(.levelwhere))),
+    the.level <- tryCatch(names(get("level", envir=sys.frame(.levelwhere))),
                           error = function(e) "UNK")
     the.time <- format(Sys.time(), datetime.fmt)
     the.namespace <- flog.namespace(.nswhere)

--- a/R/appender.R
+++ b/R/appender.R
@@ -115,7 +115,7 @@ appender.file2 <- function(format, console = FALSE,
                            default.func = "shell", datetime.fmt = "%Y%m%dT%H%M%S"){
   .nswhere = -3 # get name of the function 2 deep in the call stack
                 # that is, the function that has called flog.*
-  .funcwhere = -2 # ditto for the function name
+  .funcwhere = -3 # ditto for the function name
   .levelwhere = -1 # ditto for the current "level"
   function(line) {
     if (console) cat(line, sep='')

--- a/R/appender.R
+++ b/R/appender.R
@@ -118,7 +118,7 @@ appender.file2 <- function(format, console = FALSE,
   .funcwhere = -2 # ditto for the function name
   .levelwhere = -1 # ditto for the current "level"
   function(line) {
-    if (tee) cat(line, sep='')
+    if (console) cat(line, sep='')
     the.level <- tryCatch(names(get("level", env=sys.frame(.levelwhere))),
                           error = function(e) "UNK")
     the.time <- format(Sys.time(), datetime.fmt)

--- a/R/appender.R
+++ b/R/appender.R
@@ -40,7 +40,7 @@
 #'
 #' \code{appender.file2} is similar, but the filename is dynamically
 #' determined at runtime. It may include most of the same tokens as
-#' \link{\code{layout.format}} (all except \code{"~m"}, the message
+#' \code{\link{layout.format}} (all except \code{"~m"}, the message
 #' itself). This allows, for instance, having separate logfiles for
 #' each log level.
 #' 

--- a/man/flog.appender.Rd
+++ b/man/flog.appender.Rd
@@ -3,6 +3,7 @@
 \name{flog.appender}
 \alias{appender.console}
 \alias{appender.file}
+\alias{appender.file2}
 \alias{appender.tee}
 \alias{flog.appender}
 \title{Manage appenders for loggers}
@@ -27,6 +28,9 @@ appender.console()
 # Write log messages to a file\cr
 appender.file(file)
 
+# Write log messages to a dynamically-named file\cr
+appender.file2(format)
+
 # Write log messages to console and a file\cr
 appender.tee(file)
 }
@@ -48,6 +52,12 @@ via flog.appender.
 argument to the function. To change the file name, just call
 \code{flog.appender(appender.file(file))} again with a new file name.
 
+\code{appender.file2} is similar, but the filename is dynamically
+determined at runtime. It may include most of the same tokens as
+\link{\code{layout.format}} (all except \code{"~m"}, the message
+itself). This allows, for instance, having separate logfiles for
+each log level.
+
 To use your own appender create a function that takes a single argument,
 which represents the log message. You need to pass a function reference to
 \code{flog.appender}.
@@ -68,6 +78,10 @@ flog.appender(appender.console(), name='my.logger')
 # Set an appender to the logger named 'my.package'. Any log operations from
 # this package will now use this appender.
 flog.appender(appender.file('my.package.out'), 'my.package')
+
+# Set an appender to a file named using the message level and calling function.
+# Also tee the messages to the console.
+flog.appender(appender.file2('~l-~f.log', console = TRUE))
 }
 }
 \author{

--- a/man/flog.appender.Rd
+++ b/man/flog.appender.Rd
@@ -54,7 +54,7 @@ argument to the function. To change the file name, just call
 
 \code{appender.file2} is similar, but the filename is dynamically
 determined at runtime. It may include most of the same tokens as
-\link{\code{layout.format}} (all except \code{"~m"}, the message
+\code{layout.format} (all except \code{"~m"}, the message
 itself). This allows, for instance, having separate logfiles for
 each log level.
 


### PR DESCRIPTION
Determine the logfile name at message log runtime. Supports all of the same tokens as `layout.format` except for `~m`.

Partially supports zatonovo/futile.logger#30, though the current implementation is for each individual log level, not "a level and higher".

```r
flog.appender(appender.file2("mylog-~l.log", console=TRUE))
```

This code will produce files such as `mylog-WARN.log` and `mylog-DEBUG.log`.

The biggest difference between this addition and your current functionality is that I chose to add `console=TRUE/FALSE` instead of a separate function, such as you've done with `appender.tee`. (It is certainly feasible to have a `appender.tee2` instead, though you start getting into code redundancy with more than 1-2 lines shared.

(The rationale for me writing this was not for "30" above but instead because, oddly enough, I needed a per-function logging capability. I think I needed to do that in order to avoid concurrency issues, since a streaming app I have logs to the same directory, and I don't know if `cat` provides atomic writes for threadsafe logging.)