### PR TITLE
Add process id information on logger

### DIFF
--- a/R/futile.logger-package.R
+++ b/R/futile.logger-package.R
@@ -81,6 +81,7 @@
 #' 
 #' \describe{
 #'   \item{layout.simple}{Writes messages with a default format}
+#'   \item{layout.simple.parallel}{Writes messages with a default format with PID}
 #'   \item{layout.json}{Generates messages in a JSON format}
 #'   \item{layout.format}{Define your own format}
 #'   \item{layout.tracearg}{Print a variable name along with its value}

--- a/R/layout.R
+++ b/R/layout.R
@@ -107,6 +107,17 @@ layout.simple <- function(level, msg, ...)
   sprintf("%s [%s] %s\n", names(level),the.time, msg)
 }
 
+layout.simple.parallel <- function(level, msg, ...)
+{
+  the.time <- format(Sys.time(), "%Y-%m-%d %H:%M:%S")
+  the.pid  <- Sys.getpid()
+  if (length(list(...)) > 0) {
+    parsed <- lapply(list(...), function(x) ifelse(is.null(x), 'NULL', x))
+    msg <- do.call(sprintf, c(msg, parsed))
+  }
+  sprintf("%s [%s %s] %s\n", names(level), the.time, the.pid, msg)
+}
+
 # Get name of a parent function in call stack
 # @param .where: where in the call stack. -1 means parent of the caller.
 .get.parent.func.name <- function(.where) {

--- a/R/layout.R
+++ b/R/layout.R
@@ -44,6 +44,7 @@
 #' \item{~n}{Namespace}
 #' \item{~f}{The calling function}
 #' \item{~m}{The message}
+#' \item{~p}{The process PID}
 #' }
 #'
 #' \code{layout.json} converts the message and any additional objects provided
@@ -141,6 +142,7 @@ layout.json <- function(level, msg, ...) {
 # ~n - Namespace
 # ~f - Calling function
 # ~m - Message
+# ~p - PID
 #
 # layout <- layout.format('[~l] [~t] [~n.~f] ~m')
 # flog.layout(layout)
@@ -154,7 +156,8 @@ layout.format <- function(format, datetime.fmt="%Y-%m-%d %H:%M:%S")
     the.time <- format(Sys.time(), datetime.fmt)
     the.namespace <- flog.namespace(.where)
     the.namespace <- ifelse(the.namespace == 'futile.logger', 'ROOT', the.namespace)
-    the.function <- .get.parent.func.name(.where) 
+    the.function <- .get.parent.func.name(.where)
+    the.pid <- Sys.getpid()
     #pattern <- c('~l','~t','~n','~f','~m')
     #replace <- c(the.level, the.time, the.namespace, the.function, msg)
     message <- gsub('~l',the.level, format, fixed=TRUE)
@@ -162,6 +165,7 @@ layout.format <- function(format, datetime.fmt="%Y-%m-%d %H:%M:%S")
     message <- gsub('~n',the.namespace, message, fixed=TRUE)
     message <- gsub('~f',the.function, message, fixed=TRUE)
     message <- gsub('~m',msg, message, fixed=TRUE)
+    message <- gsub('~p',the.pid, message, fixed=TRUE)
     sprintf("%s\n", message)
   }
 }

--- a/man/flog.layout.Rd
+++ b/man/flog.layout.Rd
@@ -5,6 +5,7 @@
 \alias{layout.format}
 \alias{layout.json}
 \alias{layout.simple}
+\alias{layout.simple.parallel}
 \alias{layout.tracearg}
 \title{Manage layouts within the 'futile.logger' sub-system}
 \arguments{

--- a/man/futile.logger-package.Rd
+++ b/man/futile.logger-package.Rd
@@ -89,6 +89,7 @@ make the log messages easy on the eyes. The package supplies several layouts:
 
 \describe{
   \item{layout.simple}{Writes messages with a default format}
+  \item{layout.simple.parallel}{Writes messages with a default format with PID}
   \item{layout.json}{Generates messages in a JSON format}
   \item{layout.format}{Define your own format}
   \item{layout.tracearg}{Print a variable name along with its value}

--- a/tests/testthat/test_layout.R
+++ b/tests/testthat/test_layout.R
@@ -8,6 +8,24 @@ test_that("Embedded format string", {
   expect_that(length(grep('log message', raw)) > 0, is_true())
 })
 
+test_that("layout.simple.parallel layout", {
+  flog.threshold(INFO)
+  flog.layout(layout.simple.parallel)
+  raw <- capture.output(flog.info("log message"))
+  flog.layout(layout.simple)
+  expect_that(length(grep(paste0('INFO [[][0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} ', Sys.getpid(), '[]]'), raw)) > 0, is_true())
+  expect_that(length(grep('log message', raw)) > 0, is_true())
+})
+
+test_that("~p token", {
+  flog.threshold(INFO)
+  flog.layout(layout.format('xxx[~l ~p]xxx'))
+  raw <- capture.output(flog.info("log message"))
+  flog.layout(layout.simple)
+  expect_that(paste0('xxx[INFO ',Sys.getpid(),']xxx') == raw, is_true())
+  expect_that(length(grep('log message', raw)) == 0, is_true())
+})
+
 test_that("Custom layout dereferences level field", {
   flog.threshold(INFO)
   flog.layout(layout.format('xxx[~l]xxx'))


### PR DESCRIPTION
adds token ``~pid`` and a function with a simple layout that includes the PID

Credit for token code goes to @r2evans

Original issue: #39