### PR TITLE
Carp test fails if run twice

### DIFF
--- a/tests/testthat/test_logger.R
+++ b/tests/testthat/test_logger.R
@@ -81,6 +81,7 @@ test_that("carp returns output", {
   flog.carp(TRUE)
   flog.threshold(WARN)
   raw <- flog.debug("foo")
+  flog.carp(FALSE)
   expect_that(length(grep('DEBUG', raw)) > 0, is_true())
 })
 


### PR DESCRIPTION
Returns flog.carp() to previous expected state by running ``flog.carp(FALSE)``