### PR TITLE
Bug fixing for  issue #40

### DIFF
--- a/R/logger.R
+++ b/R/logger.R
@@ -323,6 +323,8 @@ flog.threshold('error', name='ROOT') %as% flog.threshold(ERROR, name)
 flog.threshold('FATAL', name='ROOT') %as% flog.threshold(FATAL, name)
 flog.threshold('fatal', name='ROOT') %as% flog.threshold(FATAL, name)
 
+    
+flog.threshold(threshold, name) %::% numeric : character : .
 flog.threshold(threshold, name='ROOT') %as%
 {
   flog.logger(name, threshold=threshold)

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ an appender that logs to a URL might look like the following.
 url_appender.gen <- function(url) {
   conn <- url(url)
   function(line) {
-    file.write()
+    conn.write(line)
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -44,13 +44,15 @@ Loggers
 A logger is simply a namespace bound to a threshold, an appender, and a
 formatter. Loggers are configured automatically whenever they are 
 referenced (for example when changing the threshold) inheriting the settings
-of the root logger. To explicitly create a logger call `log.logger()`.
+of the root logger. To explicitly create a logger call `flog.logger()`.
 
 ```R
 flog.logger("tawny", WARN, appender=appender.file('tawny.log'))
 ```
+Please notice that you shall not set the name as any of the following keywords:   
+'TRACE', 'trace', 'DEBUG', 'debug', 'INFO', 'info', 'WARN', 'warn', 'ERROR', 'error', 'FATAL', 'fatal'
 
-To remove a logger, use `log.remove()`. If no such logger exists,
+To remove a logger, use `flog.remove()`. If no such logger exists,
 the command is safely ignored.
 
 ```R

--- a/tests/testthat/test_logger.R
+++ b/tests/testthat/test_logger.R
@@ -29,7 +29,7 @@ test_that("Get threshold names", {
   flog.threshold(ERROR)
   expect_that(flog.threshold() == "ERROR", is_true())  
   flog.threshold(DEBUG, name='my.package')
-  expect_that(flog.threshold(name='my.package') == DEBUG, is_true()) 
+  expect_that(flog.threshold(name='my.package') == "DEBUG", is_true()) 
 })
 
 

--- a/tests/testthat/test_logger.R
+++ b/tests/testthat/test_logger.R
@@ -25,6 +25,14 @@ test_that("Capture works as expected", {
   expect_that(grepl('dist$',raw[3]), is_true())
   })
 
+test_that("Get threshold names", {
+  flog.threshold(ERROR)
+  expect_that(flog.threshold() == "ERROR", is_true())  
+  flog.threshold(DEBUG, name='my.package')
+  expect_that(flog.threshold(name='my.package') == DEBUG, is_true()) 
+})
+
+
 context("new logger")
 test_that("Create new logger", {
   flog.threshold(ERROR)


### PR DESCRIPTION
Fix for issue #40 
After the fix, it works:
`
> library(futile.logger)
> flog.threshold(ERROR)
NULL
> flog.threshold()
[1] "ERROR"
>  flog.threshold(DEBUG, name='my.package')
NULL
> flog.threshold(name='my.package')
[1] "DEBUG"
`

The reason is `flog.threshold(name='my.package')` was originally mapped to the wrong lambda.r function. 
This function call has only one parameter, so it was mapped to the first lambda.r object that accepts one parameter: 
`
flog.threshold(threshold, name='ROOT') %as%
{
  flog.logger(name, threshold=threshold)
  invisible()
}
`

The solution is just specifying the data type of the parameter. 
After the fix, it was mapped to the correct lambda.r function: 
`
flog.threshold(name='ROOT') %as%
{
  logger <- flog.logger(name)
  names(logger$threshold)
}
`