### PR TITLE
Logging Hierarchy

### DIFF
--- a/R/appender.R
+++ b/R/appender.R
@@ -124,8 +124,8 @@ appender.file2 <- function(format, console=FALSE, inherit=TRUE,
     }
     the.level <- tryCatch(get("level", envir=sys.frame(.levelwhere)),error = err)
     the.threshold <- tryCatch(get('logger',envir=sys.frame(.levelwhere)), error=err)$threshold
-    LEVELS <- c(FATAL, ERROR, WARN, INFO, DEBUG, TRACE)
     if(inherit) {
+      LEVELS <- c(FATAL, ERROR, WARN, INFO, DEBUG, TRACE)
       levels <- names(LEVELS[the.level <= LEVELS & LEVELS <= the.threshold])
     } else levels <- names(the.level)
     the.time <- format(Sys.time(), datetime.fmt)

--- a/R/appender.R
+++ b/R/appender.R
@@ -123,12 +123,11 @@ appender.file2 <- function(format, console=FALSE, inherit=TRUE,
       stop('Illegal function call, must call from flog.trace, flog.debug, flog.info, flog.warn, flog.error, flog.fatal, etc.')
     }
     the.level <- tryCatch(get("level", envir=sys.frame(.levelwhere)),error = err)
-    the.logger <- tryCatch(get('logger',envir=sys.frame(.levelwhere)), error=err)
-    the.threshold <- the.logger$threshold
+    the.threshold <- tryCatch(get('logger',envir=sys.frame(.levelwhere)), error=err)$threshold
+    LEVELS <- c(FATAL, ERROR, WARN, INFO, DEBUG, TRACE)
     if(inherit) {
       levels <- names(LEVELS[the.level <= LEVELS & LEVELS <= the.threshold])
     } else levels <- names(the.level)
-    browser()
     the.time <- format(Sys.time(), datetime.fmt)
     the.namespace <- flog.namespace(.nswhere)
     the.namespace <- ifelse(the.namespace == 'futile.logger', 'ROOT', the.namespace)

--- a/R/appender.R
+++ b/R/appender.R
@@ -110,8 +110,8 @@ appender.tee <- function(file){
   }
 }
 
-# Write to a dynamically-named file (and optionally the console)
-appender.file2 <- function(format, console=FALSE,
+# Write to a dynamically-named file (and optionally the console), with inheritance
+appender.file2 <- function(format, console=FALSE, inherit=TRUE,
                            datetime.fmt="%Y%m%dT%H%M%S") {
   .nswhere <- -3 # get name of the function 2 deep in the call stack
                  # that is, the function that has called flog.*

--- a/R/constants.R
+++ b/R/constants.R
@@ -11,4 +11,5 @@ names(DEBUG) <- "DEBUG"
 TRACE <- 9L
 names(TRACE) <- "TRACE"
 
+LEVELS <- c(FATAL, ERROR, WARN, INFO, DEBUG, TRACE)
 

--- a/R/constants.R
+++ b/R/constants.R
@@ -11,5 +11,4 @@ names(DEBUG) <- "DEBUG"
 TRACE <- 9L
 names(TRACE) <- "TRACE"
 
-LEVELS <- c(FATAL, ERROR, WARN, INFO, DEBUG, TRACE)
 

--- a/README.md
+++ b/README.md
@@ -160,3 +160,4 @@ What's New
 + Capture output for print statements (for more complex objects)
 + New layout.tracearg
 
+

--- a/README.md
+++ b/README.md
@@ -132,12 +132,12 @@ flog.threshold(DEBUG, 'mylogger')
 flog.warn('msg2', name='mylogger')
 ```
 
-If set inherit=FALSE, will only write to `mylog-WARN.log` 
+If set `inherit=FALSE`, will only write to `mylog-WARN.log` 
 ```R
 flog.appender(appender.file2("mylog-~l.log", console=TRUE, inherit=FALSE), name='mylogger')
 flog.warn('msg3', name='mylogger')
 ```
-In this scenario, if we use flog.info, it will only write to `mylog-INFO.log`.
+In this scenario, if we use `flog.info`, it will only write to `mylog-INFO.log`.
 ```R
 flog.info('msg4', name='mylogger')
 ```

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ following appenders:
 + `appender.console`
 + `appender.file`
 + `appender.tee`
++ `appender.file2`
 
 To change the appenders assigned to a logger, use `flog.appender()`:
 ```R
@@ -115,8 +116,6 @@ url_appender.gen <- function(url) {
   }
 }
 ```
-
-flog.format("futile.matrix", fn)
 
 Logging hierarchy
 -------
@@ -150,6 +149,7 @@ prints log messages using the following format:
 
 The layouts included in the package are:
 + layout.simple - Use a default format
++ layout.simple.parallel - Use a default format with a process id
 + layout.format - Provide a customizable format string
 + layout.tracearg - Dump a variable with its name
 

--- a/README.md
+++ b/README.md
@@ -129,13 +129,17 @@ flog.warn('msg1', name='mylogger')
 If we change the threshold to `DEBUG`, it will also write to `mylog-DEBUG.log`. 
 ```R
 flog.threshold(DEBUG, 'mylogger')
-flog.warn('msg3', name='mylogger')
+flog.warn('msg2', name='mylogger')
 ```
 
 If set inherit=FALSE, will only write to `mylog-WARN.log` 
 ```R
 flog.appender(appender.file2("mylog-~l.log", console=TRUE, inherit=FALSE), name='mylogger')
-flog.warn('msg2', name='mylogger')
+flog.warn('msg3', name='mylogger')
+```
+In this scenario, if we use flog.info, it will only write to `mylog-INFO.log`.
+```R
+flog.info('msg4', name='mylogger')
 ```
 
 Layouts

--- a/README.md
+++ b/README.md
@@ -118,6 +118,26 @@ url_appender.gen <- function(url) {
 
 flog.format("futile.matrix", fn)
 
+Logging hierarchy
+-------
+We can create python-style logging hierarchy using `appender.file2`. 
+Following snippet will write to both `mylog-WARN.log` and `mylog-INFO.log`
+```R
+flog.appender(appender.file2("mylog-~l.log", console=TRUE), name='mylogger')
+flog.warn('msg1', name='mylogger')
+```
+If we change the threshold to `DEBUG`, it will also write to `mylog-DEBUG.log`. 
+```R
+flog.threshold(DEBUG, 'mylogger')
+flog.warn('msg3', name='mylogger')
+```
+
+If set inherit=FALSE, will only write to `mylog-WARN.log` 
+```R
+flog.appender(appender.file2("mylog-~l.log", console=TRUE, inherit=FALSE), name='mylogger')
+flog.warn('msg2', name='mylogger')
+```
+
 Layouts
 -------
 A layout defines how a log message is printed. The default layout.simple


### PR DESCRIPTION
Fix for #30 . 

Following snippet will write to both `mylog-WARN.log` and `mylog-INFO.log`

```
flog.appender(appender.file2("mylog-~l.log", console=TRUE), name='mylogger')
flog.warn('msg1', name='mylogger')
```
If we change the threshold to `DEBUG`, it will also write to `mylog-DEBUG.log`. 
```
flog.threshold(DEBUG, 'mylogger')
flog.warn('msg3', name='mylogger')
```

If set inherit=FALSE, will only write to `mylog-WARN.log` 
```
flog.appender(appender.file2("mylog-~l.log", console=TRUE, inherit=FALSE), name='mylogger')
flog.warn('msg2', name='mylogger')
```
This PR is based on PR #38 