### PR TITLE
Provide the possibility of passing the logger object directly

### DIFF
--- a/R/logger.R
+++ b/R/logger.R
@@ -109,11 +109,11 @@
 #' @aliases flog.trace flog.debug flog.info flog.warn flog.error flog.fatal
 #' @param msg The message to log
 #' @param name The logger name to use
+#' @param capture Capture print output of variables instead of interpolate
 #' @param logger The logger to use. If \code{NULL} (the default), it is 
 #' looked up based on \code{name}. Provide \code{logger} explicitely if 
 #' the speed of the evaluation of log level is of concern (e.g., a 
 #' \code{flog.trace} call in your function which has to be run many times).
-#' @param capture Capture print output of variables instead of interpolate
 #' @param \dots Optional arguments to populate the format string
 #' @param expr An expression to evaluate
 #' @param finally An optional expression to evaluate at the end

--- a/R/logger.R
+++ b/R/logger.R
@@ -6,22 +6,22 @@
 #' 
 #' @section Usage:
 #' # Conditionally print a log statement at TRACE log level\cr
-#' flog.trace(msg, ..., name=flog.namespace(), capture=FALSE)
+#' flog.trace(msg, ..., name=flog.namespace(), logger=NULL, capture=FALSE)
 #'
 #' # Conditionally print a log statement at DEBUG log level\cr
-#' flog.debug(msg, ..., name=flog.namespace(), capture=FALSE)
+#' flog.debug(msg, ..., name=flog.namespace(), logger=NULL, capture=FALSE)
 #'
 #' # Conditionally print a log statement at INFO log level\cr
-#' flog.info(msg, ..., name=flog.namespace(), capture=FALSE)
+#' flog.info(msg, ..., name=flog.namespace(), logger=NULL, capture=FALSE)
 #'
 #' # Conditionally print a log statement at WARN log level\cr
-#' flog.warn(msg, ..., name=flog.namespace(), capture=FALSE)
+#' flog.warn(msg, ..., name=flog.namespace(), logger=NULL, capture=FALSE)
 #'
 #' # Conditionally print a log statement at ERROR log level\cr
-#' flog.error(msg, ..., name=flog.namespace(), capture=FALSE)
+#' flog.error(msg, ..., name=flog.namespace(), logger=NULL, capture=FALSE)
 #'
 #' # Print a log statement at FATAL log level\cr
-#' flog.fatal(msg, ..., name=flog.namespace(), capture=FALSE)
+#' flog.fatal(msg, ..., name=flog.namespace(), logger=NULL, capture=FALSE)
 #'
 #' # Execute an expression and capture any warnings or errors
 #' ftry(expr, error=stop, finally=NULL)
@@ -74,6 +74,25 @@
 #' > flog.info("This won't print", name='my.logger') \cr
 #' > flog.error("This %s print to a file", 'will', name='my.logger') \cr
 #' 
+#' If you have a function which gets called many times, it is a good strategy 
+#' to pass the logger directly instead of its name.
+#' 
+#' Instead of this:
+#' > simulation_fun <- function(i) {
+#' >   flog.trace("We are in loop %d", i, name='my.logger')
+#' >   i
+#' > }
+#' 
+#' ... you can do this::
+#' > my_logger <- flog.logger("my.logger")
+#' > simulation_fun2 <- function(i) {
+#' >   flog.trace("We are in loop %d", i, logger=my_logger)
+#' >   i
+#' > }
+#' 
+#' > system.time(for (i in 1:1000) simulation_fun(i))
+#' > system.time(for (i in 1:1000) simulation_fun2(i))
+#' 
 #' If you define a logger that you later want to remove, use flog.remove.
 #' 
 #' The option 'capture' allows you to print out more complicated data
@@ -90,6 +109,10 @@
 #' @aliases flog.trace flog.debug flog.info flog.warn flog.error flog.fatal
 #' @param msg The message to log
 #' @param name The logger name to use
+#' @param logger The logger to use. If \code{NULL} (the default), it is 
+#' looked up based on \code{name}. Provide \code{logger} explicitely if 
+#' the speed of the evaluation of log level is of concern (e.g., a 
+#' \code{flog.trace} call in your function which has to be run many times).
 #' @param capture Capture print output of variables instead of interpolate
 #' @param \dots Optional arguments to populate the format string
 #' @param expr An expression to evaluate
@@ -130,9 +153,9 @@
 #' }
 NULL
 
-.log_level <- function(msg, ..., level, name, capture)
+.log_level <- function(msg, ..., level, name, capture, logger = NULL)
 {
-  logger <- flog.logger(name)
+  if (is.null(logger)) logger <- flog.logger(name)
   if (level > logger$threshold && (is.null(logger$carp) || !logger$carp)) {
     return(invisible())
   }
@@ -172,28 +195,28 @@ flog.namespace <- function(.where=-4)
   ifelse(is.null(ns), 'ROOT', ns)
 }
 
-flog.trace <- function(msg, ..., name=flog.namespace(), capture=FALSE) {
-  .log_level(msg, ..., level=TRACE,name=name, capture=capture)
+flog.trace <- function(msg, ..., name=flog.namespace(), capture=FALSE, logger=NULL) {
+  .log_level(msg, ..., level=TRACE,name=name, capture=capture, logger=logger)
 }
 
-flog.debug <- function(msg, ..., name=flog.namespace(), capture=FALSE) {
-  .log_level(msg, ..., level=DEBUG,name=name, capture=capture)
+flog.debug <- function(msg, ..., name=flog.namespace(), capture=FALSE, logger=NULL) {
+  .log_level(msg, ..., level=DEBUG,name=name, capture=capture, logger=logger)
 }
 
-flog.info <- function(msg, ..., name=flog.namespace(), capture=FALSE) {
-  .log_level(msg, ..., level=INFO,name=name, capture=capture)
+flog.info <- function(msg, ..., name=flog.namespace(), capture=FALSE, logger=NULL) {
+  .log_level(msg, ..., level=INFO,name=name, capture=capture, logger=logger)
 }
 
-flog.warn <- function(msg, ..., name=flog.namespace(), capture=FALSE) {
-  .log_level(msg, ..., level=WARN,name=name, capture=capture)
+flog.warn <- function(msg, ..., name=flog.namespace(), capture=FALSE, logger=NULL) {
+  .log_level(msg, ..., level=WARN,name=name, capture=capture, logger=logger)
 }
 
-flog.error <- function(msg, ..., name=flog.namespace(), capture=FALSE) {
-  .log_level(msg, ..., level=ERROR,name=name, capture=capture)
+flog.error <- function(msg, ..., name=flog.namespace(), capture=FALSE, logger=NULL) {
+  .log_level(msg, ..., level=ERROR,name=name, capture=capture, logger=logger)
 }
 
-flog.fatal <- function(msg, ..., name=flog.namespace(), capture=FALSE) {
-  .log_level(msg, ..., level=FATAL,name=name, capture=capture)
+flog.fatal <- function(msg, ..., name=flog.namespace(), capture=FALSE, logger=NULL) {
+  .log_level(msg, ..., level=FATAL,name=name, capture=capture, logger=logger)
 }
 
 #' Wrap a try block in futile.logger

--- a/man/flog.logger.Rd
+++ b/man/flog.logger.Rd
@@ -14,6 +14,11 @@
 
 \item{name}{The logger name to use}
 
+\item{logger}{The logger to use. If \code{NULL} (the default), it is 
+looked up based on \code{name}. Provide \code{logger} explicitely if 
+the speed of the evaluation of log level is of concern (e.g., a 
+\code{flog.trace} call in your function which has to be run many times).}
+
 \item{capture}{Capture print output of variables instead of interpolate}
 
 \item{\dots}{Optional arguments to populate the format string}
@@ -30,22 +35,22 @@ in conjunction with flog.threshold to interactively change the log level.
 \section{Usage}{
 
 # Conditionally print a log statement at TRACE log level\cr
-flog.trace(msg, ..., name=flog.namespace(), capture=FALSE)
+flog.trace(msg, ..., name=flog.namespace(), logger=NULL, capture=FALSE)
 
 # Conditionally print a log statement at DEBUG log level\cr
-flog.debug(msg, ..., name=flog.namespace(), capture=FALSE)
+flog.debug(msg, ..., name=flog.namespace(), logger=NULL, capture=FALSE)
 
 # Conditionally print a log statement at INFO log level\cr
-flog.info(msg, ..., name=flog.namespace(), capture=FALSE)
+flog.info(msg, ..., name=flog.namespace(), logger=NULL, capture=FALSE)
 
 # Conditionally print a log statement at WARN log level\cr
-flog.warn(msg, ..., name=flog.namespace(), capture=FALSE)
+flog.warn(msg, ..., name=flog.namespace(), logger=NULL, capture=FALSE)
 
 # Conditionally print a log statement at ERROR log level\cr
-flog.error(msg, ..., name=flog.namespace(), capture=FALSE)
+flog.error(msg, ..., name=flog.namespace(), logger=NULL, capture=FALSE)
 
 # Print a log statement at FATAL log level\cr
-flog.fatal(msg, ..., name=flog.namespace(), capture=FALSE)
+flog.fatal(msg, ..., name=flog.namespace(), logger=NULL, capture=FALSE)
 
 # Execute an expression and capture any warnings or errors
 ftry(expr, error=stop, finally=NULL)
@@ -101,6 +106,25 @@ are copied from the parent logger.
 > flog.threshold(ERROR, name='my.logger') \cr
 > flog.info("This won't print", name='my.logger') \cr
 > flog.error("This %s print to a file", 'will', name='my.logger') \cr
+
+If you have a function which gets called many times, it is a good strategy 
+to pass the logger directly instead of its name.
+
+Instead of this:
+> simulation_fun <- function(i) {
+>   flog.trace("We are in loop %d", i, name='my.logger')
+>   i
+> }
+
+... you can do this::
+> my_logger <- flog.logger("my.logger")
+> simulation_fun2 <- function(i) {
+>   flog.trace("We are in loop %d", i, logger=my_logger)
+>   i
+> }
+
+> system.time(for (i in 1:1000) simulation_fun(i))
+> system.time(for (i in 1:1000) simulation_fun2(i))
 
 If you define a logger that you later want to remove, use flog.remove.
 

--- a/man/flog.logger.Rd
+++ b/man/flog.logger.Rd
@@ -14,12 +14,12 @@
 
 \item{name}{The logger name to use}
 
+\item{capture}{Capture print output of variables instead of interpolate}
+
 \item{logger}{The logger to use. If \code{NULL} (the default), it is 
 looked up based on \code{name}. Provide \code{logger} explicitely if 
 the speed of the evaluation of log level is of concern (e.g., a 
 \code{flog.trace} call in your function which has to be run many times).}
-
-\item{capture}{Capture print output of variables instead of interpolate}
 
 \item{\dots}{Optional arguments to populate the format string}
 

--- a/tests/testthat/test_logger.R
+++ b/tests/testthat/test_logger.R
@@ -93,3 +93,26 @@ test_that("carp returns output", {
   expect_that(length(grep('DEBUG', raw)) > 0, is_true())
 })
 
+context("logger passed explicitely")
+test_that("logger can be provided explicitely", {
+  flog.threshold(DEBUG, name='my.package')
+  my_logger <- flog.logger('my.package')
+  with_logger <- capture.output(flog.info("log message", logger=my_logger))
+  expect_that(length(grep('INFO', with_logger)) > 0, is_true())
+  expect_that(length(grep('log message', with_logger)) > 0, is_true())
+})
+test_that("logger provided explicitely is much faster if nothing has to be logged", {
+  flog.threshold(INFO, name='my.package')
+  my_logger <- flog.logger('my.package')
+  fun_wn <- function(i) {
+    flog.debug("step %d", i, name='my.package')
+    i
+  }
+  fun_wl <- function(i) {
+    flog.debug("step %d", i, logger=my_logger)
+    i
+  }
+  tw <- system.time(for (i in 1:10000) fun_wn(i))["elapsed"]
+  tl <- system.time(for (i in 1:10000) fun_wl(i))["elapsed"]
+  expect_true(tw > tl*10)
+})


### PR DESCRIPTION
This PR makes it much-much faster to evaluate the need for doing anything in .log_level()