### PR TITLE
added ~i token to layout for logger name

### DIFF
--- a/R/layout.R
+++ b/R/layout.R
@@ -111,7 +111,7 @@ flog.layout(fn, name='ROOT') %as%
 # This file provides some standard formatters
 # This prints out a string in the following format:
 #   LEVEL [timestamp] message
-layout.simple <- function(level, msg, ...)
+layout.simple <- function(level, msg, id='', ...)
 {
   the.time <- format(Sys.time(), "%Y-%m-%d %H:%M:%S")
   if (length(list(...)) > 0) {
@@ -121,7 +121,7 @@ layout.simple <- function(level, msg, ...)
   sprintf("%s [%s] %s\n", names(level),the.time, msg)
 }
 
-layout.simple.parallel <- function(level, msg, ...)
+layout.simple.parallel <- function(level, msg, id='', ...)
 {
   the.time <- format(Sys.time(), "%Y-%m-%d %H:%M:%S")
   the.pid  <- Sys.getpid()
@@ -144,7 +144,7 @@ layout.simple.parallel <- function(level, msg, ...)
 }
 
 # Generates a list object, then converts it to JSON and outputs it
-layout.json <- function(level, msg, ...) {
+layout.json <- function(level, msg, id='', ...) {
   if (!requireNamespace("jsonlite", quietly=TRUE))
     stop("layout.json requires jsonlite. Please install it.", call.=FALSE)
   
@@ -175,7 +175,7 @@ layout.format <- function(format, datetime.fmt="%Y-%m-%d %H:%M:%S")
 {
   .where = -3 # get name of the function 3 deep in the call stack
               # that is, the function that has called flog.*
-  function(level, msg, ...) {
+  function(level, msg, id='', ...) {
     if (! is.null(substitute(...))) msg <- sprintf(msg, ...)
     the.level <- names(level)
     the.time <- format(Sys.time(), datetime.fmt)
@@ -183,6 +183,7 @@ layout.format <- function(format, datetime.fmt="%Y-%m-%d %H:%M:%S")
     the.namespace <- ifelse(the.namespace == 'futile.logger', 'ROOT', the.namespace)
     the.function <- .get.parent.func.name(.where)
     the.pid <- Sys.getpid()
+    the.id <- ifelse(id %in% c('', 'futile.logger'), 'ROOT', id) 
     #pattern <- c('~l','~t','~n','~f','~m')
     #replace <- c(the.level, the.time, the.namespace, the.function, msg)
     message <- gsub('~l',the.level, format, fixed=TRUE)
@@ -191,11 +192,12 @@ layout.format <- function(format, datetime.fmt="%Y-%m-%d %H:%M:%S")
     message <- gsub('~f',the.function, message, fixed=TRUE)
     message <- gsub('~m',msg, message, fixed=TRUE)
     message <- gsub('~p',the.pid, message, fixed=TRUE)
+    message <- gsub('~i',the.id, message, fixed=TRUE)
     sprintf("%s\n", message)
   }
 }
 
-layout.tracearg <- function(level, msg, ...)
+layout.tracearg <- function(level, msg, id='', ...)
 {
   the.time <- format(Sys.time(), "%Y-%m-%d %H:%M:%S")
   if (is.character(msg)) {
@@ -228,7 +230,7 @@ layout.graylog <- function(common.fields, datetime.fmt="%Y-%m-%d %H:%M:%S")
   
   missing.common.fields <- missing(common.fields)
   
-  function(level, msg, ...) {
+  function(level, msg, id='', ...) {
     
     if (! is.null(substitute(...))) msg <- sprintf(msg, ...)
     

--- a/R/layout.R
+++ b/R/layout.R
@@ -51,6 +51,7 @@
 #' \item{~f}{The calling function}
 #' \item{~m}{The message}
 #' \item{~p}{The process PID}
+#' \item{~i}{Logger name}
 #' }
 #'
 #' \code{layout.json} converts the message and any additional objects provided

--- a/R/logger.R
+++ b/R/logger.R
@@ -141,9 +141,9 @@ NULL
   layout <- flog.layout(name)
   if (capture) {
     values <- paste(capture.output(print(...)), collapse='\n')
-    message <- c(layout(level, msg), "\n", values, "\n")
+    message <- c(layout(level, msg, name), "\n", values, "\n")
   } else {
-    message <- layout(level, msg, ...)
+    message <- layout(level, msg, name, ...)
   }
   if (level <= logger$threshold) appender(message)
   invisible(message)

--- a/tests/testthat/test_layout.R
+++ b/tests/testthat/test_layout.R
@@ -26,6 +26,24 @@ test_that("~p token", {
   expect_that(length(grep('log message', raw)) == 0, is_true())
 })
 
+test_that("~i token (logger name)", {
+  flog.threshold(INFO)
+  flog.layout(layout.format('<~i> ~m'))
+  # with no logger name 
+  # (perhaps due to the behavior of flog.namespace for nested function call, 
+  #  logger name becomes "base" instead of "futile.logger" 
+  #  when no name is given.  this test is currently disabled)
+  #out <- flog.info("log message")
+  #out <- sub('[[:space:]]+$', '', out)  # remove line break at end
+  #expect_equal(out, '<ROOT> log message')
+
+  # with logger name
+  out <- capture.output(flog.info("log message", name='mylogger'))
+  expect_equal(out, '<mylogger> log message')
+  
+  invisible(flog.layout(layout.simple))  # back to the default layout
+})
+
 test_that("Custom layout dereferences level field", {
   flog.threshold(INFO)
   flog.layout(layout.format('xxx[~l]xxx'))


### PR DESCRIPTION
I added a layout option to include logger names to message format (for my own issue #69 )
Since "~n" token is already being used, I used "~i" for logger name (stands for identifier).

The approach was to add another argument `name` to the layout functions (with default value `name=''` to avoid possible conflicts with other functionalities).

A unit test has been added too.

Minimal example:

```
flog.layout(layout.format('[~l] [~i] ~m'))
flog.info("hello", name="mylogger")
#[INFO] [mylogger] hello
```