### PR TITLE
Fixed Graylog support

### DIFF
--- a/R/appender.R
+++ b/R/appender.R
@@ -178,8 +178,8 @@ appender.graylog <- function(server, port, debug = FALSE) {
   function(line) {
 
     ret <- httr::POST(paste0("http://", server, ":", port, "/gelf"), 
-                      body = line,
-                      encode = 'form')
+                      body = list(short_message = line),
+                      encode = 'json')
     
     if (debug) print(ret)
   }


### PR DESCRIPTION
Graylog GELF HTTP required data to be sent as a JSON over POST