### PR TITLE
layout.glue

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,8 @@ Imports:
 Suggests:
     testthat,
     jsonlite,
-    httr
+    httr,
+    glue
 Description: Provides a simple yet powerful logging utility. Based loosely on
     log4j, futile.logger takes advantage of R idioms to make logging a
     convenient and easy to use replacement for cat and print statements.

--- a/R/layout.R
+++ b/R/layout.R
@@ -14,6 +14,9 @@
 #' # Decorate log messages with a standard format\cr
 #' layout.simple(level, msg, ...)
 #' 
+#' # Decorate log messages with a standard format using glue instead of sprintf\cr
+#' layout.glue(level, msg, ...)
+#'
 #' # Decorate log messages with a standard format and a pid\cr
 #' layout.simple.parallel(level, msg, ...)
 #'
@@ -75,7 +78,7 @@
 #'                                                 env = "production")))
 #' 
 #' @name flog.layout
-#' @aliases layout.simple layout.simple.parallel layout.format layout.tracearg layout.json layout.graylog
+#' @aliases layout.simple layout.simple.parallel layout.format layout.tracearg layout.json layout.graylog layout.glue
 #' @param \dots Used internally by lambda.r
 #' @author Brian Lee Yung Rowe
 #' @seealso \code{\link{flog.logger}} \code{\link{flog.appender}}

--- a/R/layout.R
+++ b/R/layout.R
@@ -253,3 +253,11 @@ layout.graylog <- function(common.fields, datetime.fmt="%Y-%m-%d %H:%M:%S")
     
   }
 }  
+
+layout.glue <- function(level, msg, id='', ...)
+{
+  if (!requireNamespace("glue", quietly=TRUE))
+    stop("layout.glue requires glue. Please install it.", call.=FALSE)
+  msg <- do.call(glue::glue, c(msg, list(...)), envir = parent.frame(3))
+  layout.simple(level, msg)
+}

--- a/man/flog.layout.Rd
+++ b/man/flog.layout.Rd
@@ -8,6 +8,7 @@
 \alias{layout.tracearg}
 \alias{layout.json}
 \alias{layout.graylog}
+\alias{layout.glue}
 \title{Manage layouts within the 'futile.logger' sub-system}
 \arguments{
 \item{\dots}{Used internally by lambda.r}
@@ -27,6 +28,9 @@ flog.layout(fn, name='ROOT')
 
 # Decorate log messages with a standard format\cr
 layout.simple(level, msg, ...)
+
+# Decorate log messages with a standard format using glue instead of sprintf\cr
+layout.glue(level, msg, ...)
 
 # Decorate log messages with a standard format and a pid\cr
 layout.simple.parallel(level, msg, ...)

--- a/tests/testthat/test_layout.R
+++ b/tests/testthat/test_layout.R
@@ -101,3 +101,11 @@ test_that("Function name detection inside nested functions", {
     flog.layout(layout.simple)
 })
 
+context("glue layout")
+default.layout <- flog.layout()
+flog.layout(layout.glue)
+test_that("glue features work", {
+  expect_equal(sub('[A-Z]* \\[.*\\] ', '', capture.output(flog.info('foobar'))),
+               'foobar')
+})
+invisible(flog.layout(default.layout))

--- a/tests/testthat/test_layout.R
+++ b/tests/testthat/test_layout.R
@@ -117,6 +117,8 @@ test_that("glue features work", {
   expect_equal(drop_log_prefix(capture.output(flog.info('foo{b}'))),
                'foobar')
   rm(b)
+  expect_equal(drop_log_prefix(capture.output(flog.info('foo', 'bar'))),
+               'foobar')
 })
 
 ## back to the default layout

--- a/tests/testthat/test_layout.R
+++ b/tests/testthat/test_layout.R
@@ -100,11 +100,23 @@ test_that("Function name detection inside nested functions", {
     expect_equal('[a] inside A', capture.output(e()))
 })
 
+drop_log_prefix <- function(msg) {
+    sub('[A-Z]* \\[.*\\] ', '', msg)
+}
+
 context("glue layout")
 flog.layout(layout.glue)
 test_that("glue features work", {
-  expect_equal(sub('[A-Z]* \\[.*\\] ', '', capture.output(flog.info('foobar'))),
+  expect_equal(drop_log_prefix(capture.output(flog.info('foobar'))),
                'foobar')
+  expect_equal(drop_log_prefix(capture.output(flog.info('{a}{b}', a = 'foo', b = 'bar'))),
+               'foobar')
+  expect_equal(drop_log_prefix(capture.output(flog.info('foo{b}', b = 'bar'))),
+               'foobar')
+  b <- 'bar'
+  expect_equal(drop_log_prefix(capture.output(flog.info('foo{b}'))),
+               'foobar')
+  rm(b)
 })
 
 ## back to the default layout

--- a/tests/testthat/test_layout.R
+++ b/tests/testthat/test_layout.R
@@ -53,6 +53,7 @@ test_that("Custom layout dereferences level field", {
 })
 
 context("null values")
+flog.layout(default.layout)
 test_that("Raw null value is printed", {
   raw <- capture.output(flog.info('xxx[%s]xxx', NULL))
   expect_that(length(grep('xxx[NULL]xxx', raw, fixed=TRUE)) == 1, is_true())

--- a/tests/testthat/test_layout.R
+++ b/tests/testthat/test_layout.R
@@ -1,4 +1,8 @@
 # :vim set ff=R
+
+## record default layout so that we can restore later
+default.layout <- flog.layout()
+
 context("format string")
 test_that("Embedded format string", {
   flog.threshold(INFO)
@@ -12,7 +16,6 @@ test_that("layout.simple.parallel layout", {
   flog.threshold(INFO)
   flog.layout(layout.simple.parallel)
   raw <- capture.output(flog.info("log message"))
-  flog.layout(layout.simple)
   expect_that(length(paste0('INFO [[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} ', Sys.getpid(), '] log message') ==  raw) > 0, is_true())
   expect_that(length(grep('log message', raw)) > 0, is_true())
 })
@@ -21,7 +24,6 @@ test_that("~p token", {
   flog.threshold(INFO)
   flog.layout(layout.format('xxx[~l ~p]xxx'))
   raw <- capture.output(flog.info("log message"))
-  flog.layout(layout.simple)
   expect_that(paste0('xxx[INFO ',Sys.getpid(),']xxx') == raw, is_true())
   expect_that(length(grep('log message', raw)) == 0, is_true())
 })
@@ -40,15 +42,12 @@ test_that("~i token (logger name)", {
   # with logger name
   out <- capture.output(flog.info("log message", name='mylogger'))
   expect_equal(out, '<mylogger> log message')
-  
-  invisible(flog.layout(layout.simple))  # back to the default layout
 })
 
 test_that("Custom layout dereferences level field", {
   flog.threshold(INFO)
   flog.layout(layout.format('xxx[~l]xxx'))
   raw <- capture.output(flog.info("log message"))
-  flog.layout(layout.simple)
   expect_that('xxx[INFO]xxx' == raw, is_true())
   expect_that(length(grep('log message', raw)) == 0, is_true())
 })
@@ -98,14 +97,14 @@ test_that("Function name detection inside nested functions", {
     d <- function() { b() }
     e <- function() { d() }
     expect_equal('[a] inside A', capture.output(e()))
-    flog.layout(layout.simple)
 })
 
 context("glue layout")
-default.layout <- flog.layout()
 flog.layout(layout.glue)
 test_that("glue features work", {
   expect_equal(sub('[A-Z]* \\[.*\\] ', '', capture.output(flog.info('foobar'))),
                'foobar')
 })
+
+## back to the default layout
 invisible(flog.layout(default.layout))


### PR DESCRIPTION
This is a basic implementation of using the `glue` package for the logging layout instead of relying on `sprintf` in the default layout. I tried to follow the code style of the package, but let me know if something looks odd.