### PR TITLE
Improve logging performance

### DIFF
--- a/R/logger.R
+++ b/R/logger.R
@@ -160,8 +160,8 @@ NULL
     return(invisible())
   }
 
-  appender <- flog.appender(name)
-  layout <- flog.layout(name)
+  appender <- logger$appender
+  layout <- logger$layout
   if (capture) {
     values <- paste(capture.output(print(...)), collapse='\n')
     message <- c(layout(level, msg, name), "\n", values, "\n")


### PR DESCRIPTION
This is a simple change in the internal `.log_level()` function. Instead of using `flog.appender()` and `flog.layout()` to get the appropriate appender and layout, I think we can just take them out of the logger object instead.

It's possible I've misunderstood the role of `flog.appender()` and `flog.layout()`, so feel free to correct me.

Otherwise, this simple change makes basic logging about 4x faster:

```r
library(microbenchmark)
library(futile.logger)

flog.appender(appender.console())
flog.threshold(INFO)

microbenchmark(
  flog.debug("message"),
  flog.info("message"),
  times = 500,
  control = list(warmups = 20)
)
```

### Before

```
Unit: microseconds
                  expr      min        lq     mean   median       uq       max neval
 flog.debug("message")  290.843  304.8445  333.223  318.716  328.834  2284.813   500
  flog.info("message") 1449.648 1488.2195 1703.462 1508.030 1534.488 53926.177   500
```

### After

```
Unit: microseconds
                  expr     min       lq     mean   median       uq      max neval
 flog.debug("message") 268.802 280.4005 292.1603 288.7520 294.5395 1967.425   500
  flog.info("message") 409.698 418.8930 431.8080 426.6665 433.4650 2079.260   500
```

(The debug messages are below the threshold, and serve as an illustration of the base case.)