### PR TITLE
appender for AWS kinesis streams

### DIFF
--- a/R/appender.R
+++ b/R/appender.R
@@ -184,3 +184,15 @@ appender.graylog <- function(server, port, debug = FALSE) {
     if (debug) print(ret)
   }
 }
+
+appender.kinesis_handler <- function(stream,region_name,partition_key)
+{
+
+  function(line) {
+      library(AWR.Kinesis)
+      AWR.Kinesis::kinesis_put_record(stream,region = region_name,line,partition_key)
+
+
+  }
+}
+


### PR DESCRIPTION
added code to pipeline data with AWR library into the AWS kinesis streams: https://github.com/daroczig/AWR.Kinesis


#flog.appender(appender.kinesis_handler('logging_data','us-east-2','LOL'), 'kinesis')