### PR TITLE
add colored layout fix #59

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,8 @@ Imports:
 Suggests:
     testthat,
     jsonlite,
-    httr
+    httr,
+    crayon
 Description: Provides a simple yet powerful logging utility. Based loosely on
     log4j, futile.logger takes advantage of R idioms to make logging a
     convenient and easy to use replacement for cat and print statements.
@@ -30,4 +31,4 @@ Collate:
     'logger.R'
     'scat.R'
     'futile.logger-package.R'
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.0

--- a/R/layout.R
+++ b/R/layout.R
@@ -14,6 +14,9 @@
 #' # Decorate log messages with a standard format\cr
 #' layout.simple(level, msg, ...)
 #' 
+#' # Decorate log messages with a standard format colored by log level\cr
+#' layout.colored(level, msg, ...)
+#'
 #' # Decorate log messages with a standard format and a pid\cr
 #' layout.simple.parallel(level, msg, ...)
 #'
@@ -253,3 +256,31 @@ layout.graylog <- function(common.fields, datetime.fmt="%Y-%m-%d %H:%M:%S")
     
   }
 }  
+layout.colored <- function(level, msg, id='', ...)
+{
+
+  if (!requireNamespace("crayon", quietly = TRUE)) {
+    stop("Colored logging requires the 'crayon' package to be installed.")
+  }
+
+  the.time <- format(Sys.time(), "[%Y-%m-%d %H:%M:%S]")
+
+  if (length(list(...)) > 0) {
+    parsed <- lapply(list(...), function(x) if(is.null(x)) 'NULL' else x )
+    msg <- do.call(sprintf, c(msg, parsed))
+  }
+
+  color <- switch(
+    names(level),
+    'FATAL' = function(x) crayon::bgRed(crayon::black(x)),
+    'ERROR' = crayon::red,
+    'WARN'  = crayon::yellow,
+    'INFO'  = crayon::blue,
+    'DEBUG' = crayon::silver,
+    'TRACE' = crayon::blurred,
+    crayon::white
+    )
+
+  color(paste(crayon::bold(names(level)), the.time, msg, crayon::reset('\n')))
+
+}

--- a/man/flog.layout.Rd
+++ b/man/flog.layout.Rd
@@ -8,6 +8,7 @@
 \alias{layout.tracearg}
 \alias{layout.json}
 \alias{layout.graylog}
+\alias{layout.colored}
 \title{Manage layouts within the 'futile.logger' sub-system}
 \arguments{
 \item{\dots}{Used internally by lambda.r}
@@ -27,6 +28,9 @@ flog.layout(fn, name='ROOT')
 
 # Decorate log messages with a standard format\cr
 layout.simple(level, msg, ...)
+
+# Decorate log messages with a standard format colored by log level\cr
+layout.colored(level, msg, ...)
 
 # Decorate log messages with a standard format and a pid\cr
 layout.simple.parallel(level, msg, ...)


### PR DESCRIPTION
Adds a new layout for colored logs. Example:

![image](https://user-images.githubusercontent.com/495736/47121245-40cbc180-d272-11e8-8386-eff272c0083b.png)
