### PR TITLE
Mention URL in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,3 +35,4 @@ Collate:
     'util.R'
     'futile.logger-package.R'
 RoxygenNote: 7.1.2
+URL: https://github.com/zatonovo/futile.logger


### PR DESCRIPTION
Came across this while checking if the CRAN issues due to the testthat update (https://cran.r-project.org/web/checks/check_results_futile.logger.html) are perhaps fixed in dev.

Having this URL improves discoverability -- I know Hadley shared PRs fixing the revdep breakages of testthat packages found on CRAN. I'm not sure if he did so for packages that require sharing a package over e-mail.